### PR TITLE
Update ProximaGrpcSearchClient.java

### DIFF
--- a/sdk/java/src/main/java/com/alibaba/proxima/be/client/ProximaGrpcSearchClient.java
+++ b/sdk/java/src/main/java/com/alibaba/proxima/be/client/ProximaGrpcSearchClient.java
@@ -369,8 +369,10 @@ public class ProximaGrpcSearchClient implements ProximaSearchClient {
       throw new ProximaSEException("Rows is empty.");
     }
     for (WriteRequest.Row row : rows) {
-      if (row.getIndexValues() == null || row.getIndexValues().getValuesCount() == 0) {
-        throw new ProximaSEException("Index column values is empty in Row.");
+      if(row.getOperationType() != WriteRequest.OperationType.DELETE){
+        if (row.getIndexValues() == null || row.getIndexValues().getValuesCount() == 0) {
+          throw new ProximaSEException("Index column values is empty in Row.");
+        }
       }
     }
   }


### PR DESCRIPTION
fix bug, if WriteRequest.Row OperationType is WriteRequest.OperationType.DELETE, allow IndexValues is null.